### PR TITLE
Fix build on current nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![deny(missing_docs)]
 #![feature(const_fn)]
+#![feature(const_unsafe_cell_new)]
 #![no_std]
 
 extern crate static_ref;


### PR DESCRIPTION
Compiling with rustc 1.22.0-nightly (185cc5f26 2017-10-02) failed with:

error: `<core::cell::UnsafeCell<T>>::new` is not yet stable as a const fn
  --> src/lib.rs:46:26
   |
46 |         Resource { data: UnsafeCell::new(value) }
   |                          ^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: in Nightly builds, add `#![feature(const_unsafe_cell_new)]` to the crate attributes to enable